### PR TITLE
Add `set-up-ballerina` to connector release workflow

### DIFF
--- a/.github/workflows/release-package-connector-template.yml
+++ b/.github/workflows/release-package-connector-template.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: latest
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## Purpose
The purpose of this PR is to address the issue raised in [Issue: Getting error `bal: command not found` on example build in connector release](https://github.com/ballerina-platform/ballerina-library/issues/5928). The problem arises from the absence of a Ballerina environment in the `release-package-connector-template`, leading to build failures when attempting to execute Ballerina commands.

## Goals
The primary goal of this PR is to set up the Ballerina environment in the `release-package-connector-template`, ensuring that users can successfully build the example in the connector release without encountering the `bal: command not found` error.

## Approach
To achieve this goal, the implementation involves configuring the necessary Ballerina binaries and dependencies in the `release-package-connector-template`. The changes ensure that the Ballerina environment is properly initialized, allowing users to execute Ballerina commands seamlessly during the build process. 

## Related PRs
https://github.com/ballerina-platform/ballerina-library/issues/5928