### PR TITLE
Add Persist Redis module as a Ballerina Extended module

### DIFF
--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -133,6 +133,10 @@
         {
             "name": "module-ballerinax-persist.sql",
             "version_key": "stdlibPersistSqlVersion"
+        },
+        {
+            "name": "module-ballerinax-persist.redis",
+            "version_key": "stdlibPersistRedisVersion"
         }
     ],
     "connectors": [

--- a/release/resources/stdlib_modules.json
+++ b/release/resources/stdlib_modules.json
@@ -503,6 +503,16 @@
             "release": true,
             "dependents": [],
             "display_code_cov_badge": true
+        },
+        {
+            "name": "module-ballerinax-persist.redis",
+            "module_version": "0.1.0-SNAPSHOT",
+            "level": 1,
+            "default_branch": "main",
+            "version_key": "stdlibPersistRedisVersion",
+            "release": true,
+            "dependents": [],
+            "display_code_cov_badge": true
         }
     ],
     "connectors": [


### PR DESCRIPTION
## Purpose
To list `persist.redis` as a Ballerina Extended module in Ballerina Library