### PR TITLE
Fix Ballerina lang windows build failure in GraalVM check

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -150,7 +150,7 @@ jobs:
               if: ${{ inputs.lang_version == '' }}
               run: |
                   perl -pi -e "s/^\s*version=.*/version=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
-                  ./gradlew.bat build -x test publishToMavenLocal --continue -x createJavadoc --stacktrace -scan --console=plain --no-daemon --no-parallel
+                  ./gradlew.bat build -x test publishToMavenLocal --continue -x javadoc --stacktrace -scan --console=plain --no-daemon --no-parallel
 
             - name: Set up GraalVM
               uses: graalvm/setup-graalvm@v1

--- a/resources/workflow-scripts/trigger-graalvm-check.bal
+++ b/resources/workflow-scripts/trigger-graalvm-check.bal
@@ -131,7 +131,7 @@ public function main() returns error? {
 function triggerGraalVMChecks(Data data) returns map<LevelStatus> {
     map<LevelStatus> result = {};
 
-    foreach Module module in data.modules {
+    foreach Module module in data.library_modules {
         result = triggerGraalVMCheck(module, result);
     }
 

--- a/resources/workflow-scripts/trigger-graalvm-check.bal
+++ b/resources/workflow-scripts/trigger-graalvm-check.bal
@@ -85,7 +85,7 @@ type Module record {
 };
 
 type Data record {
-    Module[] modules;
+    Module[] library_modules;
     Module[] extended_modules;
 };
 


### PR DESCRIPTION
## Purpose

The GraalVM windows builds in all the standard libraries are failing when building the lang master. This is due to the recent gradle task name change in the ballerina lang repo. (`createJavadoc` -> `javadoc`)

This PR is to address the above issue.