### PR TITLE
Add workflow templates for s/4hana connector

### DIFF
--- a/.github/workflows/s4hana-build-connector-template.yml
+++ b/.github/workflows/s4hana-build-connector-template.yml
@@ -1,0 +1,96 @@
+name: Build (S/4 HANA Connector)
+
+on:
+  workflow_call:
+    inputs:
+      hana-connector-group:
+        required: true
+        type: string
+
+jobs:
+  build-examples:
+    name: Build Examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: latest
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Build the Package
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew :${{ inputs.hana-connector-group }}-examples:build :${{ inputs.hana-connector-group }}-sanitation:build -x :${{ inputs.hana-connector-group }}-ballerina:build
+
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.set-matrix.outputs.directories }}
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+      - name: Set matrix for build
+        id: set-matrix
+        run: |
+          folders=()
+          cd ballerina
+          for dir in $(find . -type d -maxdepth 1  -mindepth 1 | cut -c3-); do
+            if [[ "$dir" == resources ]]; then
+              continue
+            fi
+            folders+=("$dir"); 
+          done
+          echo "directories=$(jq -nc --args '$ARGS.positional' ${folders[@]})" >> $GITHUB_OUTPUT
+
+  build-connectors:
+    name: Build Connectors
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    strategy:
+      matrix: 
+        directory: ${{ fromJSON(needs.generate-matrix.outputs.directories) }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Build the Package
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:build -x test -PbuildUsingDocker=nightly
+          ./gradlew :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:test -PbuildUsingDocker=nightly
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v3
+        with:
+          path: ballerina/**/coverage-report.xml
+
+  upload-codcov:
+    name: Upload Codecov
+    runs-on: ubuntu-latest
+    needs: build-connectors
+    steps:
+      - name: Download coverage reports
+        uses: actions/download-artifact@v3
+
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/s4hana-build-with-bal-test-graalvm.yml
+++ b/.github/workflows/s4hana-build-with-bal-test-graalvm.yml
@@ -1,0 +1,75 @@
+name: Build with bal test graalvm (S/4 HANA Connector)
+
+on:
+  workflow_call:
+    inputs:
+      hana-connector-group:
+        required: true
+        type: string
+
+jobs:
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.set-matrix.outputs.directories }}
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+      - name: Set matrix for build
+        id: set-matrix
+        run: |
+          folders=()
+          cd ballerina
+          for dir in $(find . -type d -maxdepth 1  -mindepth 1 | cut -c3-); do
+            if [[ "$dir" == resources ]]; then
+              continue
+            fi
+            folders+=("$dir"); 
+          done
+          echo "directories=$(jq -nc --args '$ARGS.positional' ${folders[@]})" >> $GITHUB_OUTPUT
+
+  build:
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    strategy:
+      matrix: 
+        directory: ${{ fromJSON(needs.generate-matrix.outputs.directories) }}
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: latest
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "17"
+          distribution: "graalvm-community"
+          set-java-home: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check GraalVM installation
+        run: |
+          echo "GRAALVM_HOME: ${{ env.GRAALVM_HOME }}"
+          echo "JAVA_HOME: ${{ env.JAVA_HOME }}"
+          native-image --version
+
+      - name: Build Package
+        run: ./gradlew :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:build 
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove Target Directory
+        run: |
+          cd ballerina/${{ matrix.directory }}
+          sudo rm -rf target
+
+      - name: Test with GraalVM
+        run: |
+          cd ballerina/${{ matrix.directory }}
+          IS_BAL_BUILD=true bal test --graalvm 

--- a/.github/workflows/s4hana-daily-build-connector-template.yml
+++ b/.github/workflows/s4hana-daily-build-connector-template.yml
@@ -1,0 +1,100 @@
+name: Daily Build (S/4 HANA Connector)
+
+on:
+  workflow_call:
+    inputs:
+      hana-connector-group:
+        required: true
+        type: string
+
+jobs:
+  build-examples:
+    name: Build Examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: latest
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Build the Package
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew :${{ inputs.hana-connector-group }}-examples:build :${{ inputs.hana-connector-group }}-sanitation:build -x :${{ inputs.hana-connector-group }}-ballerina:build
+
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.set-matrix.outputs.directories }}
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+      - name: Set matrix for build
+        id: set-matrix
+        run: |
+          folders=()
+          cd ballerina
+          for dir in $(find . -type d -maxdepth 1  -mindepth 1 | cut -c3-); do
+            if [[ "$dir" == resources ]]; then
+              continue
+            fi
+            folders+=("$dir"); 
+          done
+          echo "directories=$(jq -nc --args '$ARGS.positional' ${folders[@]})" >> $GITHUB_OUTPUT
+
+  build-connectors:
+    name: Build Connectors
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    strategy:
+      matrix: 
+        directory: ${{ fromJSON(needs.generate-matrix.outputs.directories) }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Build the Package
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:build -x test -PbuildUsingDocker=nightly
+          ./gradlew :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:test -PbuildUsingDocker=nightly
+
+  send-notification:
+    name: Send Failure Notification
+    runs-on: ubuntu-latest
+    needs: [build-examples, build-connectors]
+    if: ${{ failure() }}
+    steps:
+      # Send notification when build fails
+      - name: Notify failure
+        run: |
+          curl -X POST \
+          'https://api.github.com/repos/ballerina-platform/ballerina-release/dispatches' \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
+          --data "{
+            \"event_type\": \"notify-build-failure\",
+            \"client_payload\": {
+              \"repoName\": \"module-ballerinax-sap.s4hana.${{ inputs.hana-connector-group }}\"
+            }
+          }"

--- a/.github/workflows/s4hana-dev-stage-central-publish-template.yml
+++ b/.github/workflows/s4hana-dev-stage-central-publish-template.yml
@@ -1,0 +1,73 @@
+name: Publish to the Ballerina DEV/STAGE Central (S/4 HANA)
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+      hana-connector-group:
+        required: true
+        type: string
+
+jobs:
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.set-matrix.outputs.directories }}
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+      - name: Set matrix for build
+        id: set-matrix
+        run: |
+          folders=()
+          cd ballerina
+          for dir in $(find . -type d -maxdepth 1  -mindepth 1 | cut -c3-); do
+            if [[ "$dir" == resources ]]; then
+              continue
+            fi
+            folders+=("$dir"); 
+          done
+          echo "directories=$(jq -nc --args '$ARGS.positional' ${folders[@]})" >> $GITHUB_OUTPUT
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    strategy:
+      matrix: 
+        directory: ${{ fromJSON(needs.generate-matrix.outputs.directories) }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Ballerina Central Dev Push
+        if: ${{ inputs.environment == 'DEV CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_STAGE_CENTRAL: false
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:build -PpublishToCentral=true 
+
+      - name: Ballerina Central Stage Push
+        if: ${{ inputs.environment == 'STAGE CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: false
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:build -PpublishToCentral=true 

--- a/.github/workflows/s4hana-dev-stage-central-single-publish-template.yml
+++ b/.github/workflows/s4hana-dev-stage-central-single-publish-template.yml
@@ -1,0 +1,51 @@
+name: Publish Single Connector to the Ballerina DEV/STAGE Central (S/4 HANA)
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+      hana-connector-group:
+        required: true
+        type: string
+      hana-connector-name:
+        required: true
+        type: string
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Ballerina Central Dev Push
+        if: ${{ inputs.environment == 'DEV CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_STAGE_CENTRAL: false
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean :${{ inputs.hana-connector-group }}-ballerina:${{ inputs.hana-connector-name}}:build -PpublishToCentral=true 
+
+      - name: Ballerina Central Stage Push
+        if: ${{ inputs.environment == 'STAGE CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: false
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean :${{ inputs.hana-connector-group }}-ballerina:${{ inputs.hana-connector-name }}:build -PpublishToCentral=true 

--- a/.github/workflows/s4hana-pr-template.yml
+++ b/.github/workflows/s4hana-pr-template.yml
@@ -1,0 +1,97 @@
+name: PR Build
+
+on:
+  workflow_call:
+    inputs:
+      hana-connector-group:
+        required: true
+        type: string
+
+jobs:
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.set-matrix.outputs.directories }}
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+      - name: Set matrix for build
+        id: set-matrix
+        run: |
+          folders=()
+          cd ballerina
+          for dir in $(find . -type d -maxdepth 1  -mindepth 1 | cut -c3-); do
+            if [[ "$dir" == resources ]]; then
+              continue
+            fi
+            folders+=("$dir"); 
+          done
+          echo "directories=$(jq -nc --args '$ARGS.positional' ${folders[@]})" >> $GITHUB_OUTPUT
+
+  build-connectors:
+    name: Build Connectors
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    strategy:
+      matrix: 
+        directory: ${{ fromJSON(needs.generate-matrix.outputs.directories) }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Build the Package
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:build -x test -PbuildUsingDocker=nightly
+          ./gradlew :${{ inputs.hana-connector-group }}-ballerina:${{ matrix.directory }}:test -PbuildUsingDocker=nightly
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v3
+        with:
+          path: ballerina/**/coverage-report.xml
+
+  upload-codcov:
+    name: Upload Codecov
+    runs-on: ubuntu-latest
+    needs: build-connectors
+    steps:
+      - name: Download coverage reports
+        uses: actions/download-artifact@v3
+
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v3
+
+  build-examples:
+    name: Build Examples (Final Stage)
+    runs-on: ubuntu-latest
+    needs: build-connectors
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: latest
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17.0.7
+
+      - name: Build the Package
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew :${{ inputs.hana-connector-group }}-examples:build :${{ inputs.hana-connector-group }}-sanitation:build -x :${{ inputs.hana-connector-group }}-ballerina:build

--- a/.github/workflows/s4hana-release-template.yml
+++ b/.github/workflows/s4hana-release-template.yml
@@ -1,0 +1,105 @@
+name: Publish Release (S/4 HANA Connector)
+
+on:
+  workflow_call:
+    inputs:
+      hana-connector-group:
+        required: true
+        type: string
+      hana-connector-name:
+        required: true
+        type: string
+
+jobs:
+  call_workflow:
+    name: Release Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Get Ballerina Version
+        run: |
+          BAL_VERSION=$(grep -w 'ballerinaLangVersion' gradle.properties | cut -d= -f2 | rev | cut --complement -d- -f1 | rev) 
+          if [ -z "$BAL_VERSION" ]; then
+            BAL_VERSION="latest"
+          fi
+          echo "BAL_VERSION=$BAL_VERSION" >> $GITHUB_ENV
+          echo "Ballerina Version: $BAL_VERSION"
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: ${{ env.BAL_VERSION }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17.0.7
+
+        # This step is because this repoistory is a collection of packages
+      - name: Change version in gradle.properties
+        run: |
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          CONNECTOR_VERSION=$((grep -w '${{ inputs.hana-connector-name }}Version' | cut -d= -f2) < gradle.properties)
+          VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties)
+          if [[ "$VERSION" == "$CONNECTOR_VERSION" ]]; then
+            echo "Version is already up to date"
+            exit 0
+          fi
+          sed -i "s/version=\(.*\)/version=$CONNECTOR_VERSION/g" gradle.properties
+          git commit -m "[Automated] Update verion to match connector version" gradle.properties
+
+      - name: Build without Tests
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew build -x test 
+
+      - name: Create lib Directory if not Exists
+        run: mkdir -p ballerina/lib
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "rootfs"
+          scan-ref: "/github/workspace/ballerina/lib"
+          format: "table"
+          timeout: "10m0s"
+          exit-code: "1"
+          skip-dirs: "examples"
+
+      - name: Get Release Version
+        run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut -d- -f2 | rev)" >> $GITHUB_ENV
+
+      - name: Checkout to Release Branch
+        run: |
+          echo "Version: ${VERSION}"
+          git checkout -b release-${{ inputs.hana-connector-name }}-${VERSION}
+
+      - name: Remove Lib Directory
+        run: |
+          sudo rm -rf ballerina/lib
+
+      - name: Publish Package
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean :${{ inputs.hana-connector-group }}-ballerina:${{ inputs.hana-connector-name }}:release -x :${{ inputs.hana-connector-group }}-examples:test -Prelease.useAutomaticVersion=true 
+          ./gradlew -Pversion=${VERSION} -P${{ inputs.hana-connector-name }}Version=${VERSION} :${{ inputs.hana-connector-group }}-ballerina:${{ inputs.hana-connector-name }}:publish -x test -PpublishToCentral=true 
+
+      - name: GitHub Release and Release Sync PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          git push origin release-${{ inputs.hana-connector-name }}-${VERSION}
+          gh release create ${{ inputs.hana-connector-name }}-v$VERSION --title "${{ inputs.hana-connector-name }}-v$VERSION"
+          gh pr create --base ${GITHUB_REF##*/} --title "[Automated] Sync ${GITHUB_REF##*/} after ${{ inputs.hana-connector-name }}-$VERSION release" --body "Sync ${GITHUB_REF##*/} after ${{ inputs.hana-connector-name }}-$VERSION release"


### PR DESCRIPTION
## Purpose
Add separate workflows for s/4hana connector repositories

As these contain multiple connectors, the standard workflow templates cannot be reused due to changed folder structure and total time for a sequential build. 

Except Trivy check all workflows are tweaked to improve build times