### PR TITLE
Fix process load test results workflow

### DIFF
--- a/.github/workflows/process-load-test-results-template.yml
+++ b/.github/workflows/process-load-test-results-template.yml
@@ -58,9 +58,21 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.ballerina_bot_token }}
+      - name: Check if the load-test-results branch exists
+        if: ${{ steps.processResults.outputs.hasPassed }}
+        id: check_branch
+        run: |
+          if git ls-remote --heads origin load-test-results | grep -q "refs/heads/load-test-results"; then
+            echo "branch_exists=true" >> $GITHUB_ENV
+          else
+            echo "branch_exists=false" >> $GITHUB_ENV
+          fi
+      - name: Delete existing load-test-results branch
+        if: ${{ steps.check_branch.outputs.branch_exists }}
+        run: git push origin --delete load-test-results
       - name: Push results
         if: ${{ steps.processResults.outputs.hasPassed }}
-        run: git push origin "load-test-results"
+        run: git push origin load-test-results
         env:
           GITHUB_TOKEN: ${{ secrets.ballerina_bot_token }}
       - name: Create pull request for new summary
@@ -95,22 +107,8 @@ jobs:
       - name: Merge PR
         if: ${{ steps.processResults.outputs.hasPassed }}
         run: |
-          if [[ ${{ steps.processResults.outputs.branch }} == "null" ]]
-          then
-            checkCount="0"
-            while [ "$checkCount" != "3" ]
-            do
-              sleep 20
-              checkCount=$(gh pr status --jq '[.currentBranch .statusCheckRollup[] | select((.conclusion=="SUCCESS") and ((.name=="Run PR Build Workflow / Build on Ubuntu") or (.name=="Run PR Build Workflow / Build on Windows") or (.name=="codecov/project")))] | length' --json statusCheckRollup)
-              failedCount=$(gh pr status --jq '[.currentBranch .statusCheckRollup[] | select((.conclusion=="FAILURE") and ((.name=="Run PR Build Workflow / Build on Ubuntu") or (.name=="Run PR Build Workflow / Build on Windows") or (.name=="codecov/project")))]|length' --json statusCheckRollup)
-              if [[ "$failedCount" != "0" ]]
-              then
-                echo "PR Build has failed"
-                exit 1
-              fi
-            done
-            sleep 20
-          fi
+          gh pr checks ${{ steps.createPR.outputs.prUrl }} --required --watch --interval 20
+          sleep 5
           gh pr merge ${{ steps.createPR.outputs.prUrl }} --merge --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.ballerina_bot_token }}

--- a/.github/workflows/process-load-test-results-template.yml
+++ b/.github/workflows/process-load-test-results-template.yml
@@ -58,7 +58,7 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.ballerina_bot_token }}
-      - name: Check if the load-test-results branch exists
+      - name: Check the existence of load-test-results branch
         if: ${{ steps.processResults.outputs.hasPassed }}
         id: check_branch
         run: |
@@ -67,7 +67,7 @@ jobs:
           else
             echo "branch_exists=false" >> $GITHUB_ENV
           fi
-      - name: Delete existing load-test-results branch
+      - name: Delete the existing load-test-results branch
         if: ${{ steps.check_branch.outputs.branch_exists }}
         run: git push origin --delete load-test-results
       - name: Push results

--- a/.github/workflows/process-load-test-results-template.yml
+++ b/.github/workflows/process-load-test-results-template.yml
@@ -60,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ballerina_bot_token }}
       - name: Push results
         if: ${{ steps.processResults.outputs.hasPassed }}
-        run: git push origin load-test-results
+        run: git push origin "load-test-results"
         env:
           GITHUB_TOKEN: ${{ secrets.ballerina_bot_token }}
       - name: Create pull request for new summary

--- a/.github/workflows/process-load-test-results-template.yml
+++ b/.github/workflows/process-load-test-results-template.yml
@@ -58,18 +58,6 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.ballerina_bot_token }}
-      - name: Check the existence of load-test-results branch
-        if: ${{ steps.processResults.outputs.hasPassed }}
-        id: check_branch
-        run: |
-          if git ls-remote --heads origin load-test-results | grep -q "refs/heads/load-test-results"; then
-            echo "branch_exists=true" >> $GITHUB_ENV
-          else
-            echo "branch_exists=false" >> $GITHUB_ENV
-          fi
-      - name: Delete the existing load-test-results branch
-        if: ${{ steps.check_branch.outputs.branch_exists }}
-        run: git push origin --delete load-test-results
       - name: Push results
         if: ${{ steps.processResults.outputs.hasPassed }}
         run: git push origin load-test-results


### PR DESCRIPTION
## Purpose

The load-tests has been failing for some time due to the following issue:
- The merge PR step hangs intermittently and get timed-out, which makes the PR not merged until the next load test results PR
- Due to the above reason, there is already a `load-test-results` branch which is not sync with the master, which makes the push branch step fail

In this PR, the above issues has been addressed with the following changes:
- Use a github CLI command to wait until all the required checks pass
- Check for already existing branch and remove it before pushing the new changes - Ideally this check is not required when the PR is merged automatically