### PR TITLE
Update release package workflow template

### DIFF
--- a/.github/workflows/release-package-template.yml
+++ b/.github/workflows/release-package-template.yml
@@ -73,6 +73,7 @@ jobs:
           sed -i 's/stdlib\(.*\)=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/stdlib\1=\2/g' gradle.properties
           sed -i 's/observe\(.*\)=\(.*\)-SNAPSHOT/observe\1=\2/g' gradle.properties
           sed -i 's/observe\(.*\)=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/observe\1=\2/g' gradle.properties
+          sed -i 's/ballerinaToOpenApiVersion=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/ballerinaToOpenApiVersion=\1/g' gradle.properties
           git add gradle.properties
           git commit -m "Move dependencies to stable versions" || echo "No changes to commit"
 


### PR DESCRIPTION
## Purpose

With update 10, the `http` package has a dependency to `ballerinaToOpenApi` package which is in the `openapi-tool` repo. We need to release it first and should have the stable version in the `http` package. In this PR, the release workflow is updated with the change to support removing the timestamped version of `ballerinaToOpenApiVersion`.