### PR TITLE
Update connector workflow templates to use ballerina-bot token as the `packagePAT`

### DIFF
--- a/.github/workflows/build-connector-template.yml
+++ b/.github/workflows/build-connector-template.yml
@@ -67,8 +67,8 @@ jobs:
 
             -   name: Build the Package
                 env:
-                    packageUser: ${{ github.actor }}
-                    packagePAT: ${{ secrets.GITHUB_TOKEN }}
+                  packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                  packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
                   ./gradlew build -x test ${{ inputs.additional-build-flags }}
                   ./gradlew test ${{ inputs.additional-test-flags }}

--- a/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Build Package
         run: ./gradlew build ${{ inputs.additional-build-flags }}
         env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
 
       - name: Remove Target Directory
         run: sudo rm -rf ballerina/target

--- a/.github/workflows/daily-build-connector-template.yml
+++ b/.github/workflows/daily-build-connector-template.yml
@@ -43,15 +43,15 @@ jobs:
 
       - name: Build the Package
         env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew build -x test ${{ inputs.additional-build-flags }} -PbuildUsingDocker=nightly
 
       - name: Test the Package
         env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew test ${{ inputs.additional-test-flags }} -PbuildUsingDocker=nightly
 

--- a/.github/workflows/pr-build-connector-template.yml
+++ b/.github/workflows/pr-build-connector-template.yml
@@ -50,8 +50,8 @@ jobs:
 
             -   name: Build the Package
                 env:
-                    packageUser: ${{ github.actor }}
-                    packagePAT: ${{ secrets.GITHUB_TOKEN }}
+                    packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                    packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
                   ./gradlew build -x test ${{ inputs.additional-build-flags }}
                   ./gradlew test ${{ inputs.additional-test-flags }}

--- a/.github/workflows/release-package-connector-template.yml
+++ b/.github/workflows/release-package-connector-template.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Build without Tests
         env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
           git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}

--- a/.github/workflows/trivy-scan-template.yml
+++ b/.github/workflows/trivy-scan-template.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Build with Gradle
         env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
 
       - name: Create lib directory if not exists


### PR DESCRIPTION
## Purpose
> $subject

This change is required to build the Ballerina IBM CTG connector [1] as some of the dependent resources has been published under the `wso2-enterprise` organization and `github.token` does not have access to read packages from a private organization.

[1] - https://github.com/ballerina-platform/module-ballerinax-ibm.ctg
