### PR TITLE
Fix `TOOMANYREQUESTS` failure in Trivy Action

### DIFF
--- a/.github/workflows/central-publish-template.yml
+++ b/.github/workflows/central-publish-template.yml
@@ -46,6 +46,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"

--- a/.github/workflows/central-publish-template.yml
+++ b/.github/workflows/central-publish-template.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"

--- a/.github/workflows/release-package-connector-template.yml
+++ b/.github/workflows/release-package-connector-template.yml
@@ -71,6 +71,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"

--- a/.github/workflows/release-package-connector-template.yml
+++ b/.github/workflows/release-package-connector-template.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Run Trivy Vulnerability Scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"

--- a/.github/workflows/release-package-template.yml
+++ b/.github/workflows/release-package-template.yml
@@ -53,6 +53,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"

--- a/.github/workflows/release-package-template.yml
+++ b/.github/workflows/release-package-template.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Run Trivy Vulnerability Scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"

--- a/.github/workflows/s4hana-release-template.yml
+++ b/.github/workflows/s4hana-release-template.yml
@@ -63,6 +63,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina"

--- a/.github/workflows/s4hana-release-template.yml
+++ b/.github/workflows/s4hana-release-template.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Run Trivy Vulnerability Scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina"

--- a/.github/workflows/s4hana-trivy-scan.yml
+++ b/.github/workflows/s4hana-trivy-scan.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina"

--- a/.github/workflows/s4hana-trivy-scan.yml
+++ b/.github/workflows/s4hana-trivy-scan.yml
@@ -29,6 +29,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina"

--- a/.github/workflows/trivy-scan-template.yml
+++ b/.github/workflows/trivy-scan-template.yml
@@ -34,6 +34,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"

--- a/.github/workflows/trivy-scan-template.yml
+++ b/.github/workflows/trivy-scan-template.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: "rootfs"
           scan-ref: "${{ github.workspace }}/ballerina/lib"


### PR DESCRIPTION
## Purpose
> $Subject

Failure: https://github.com/ballerina-platform/module-ballerina-jballerina.java.arrays/actions/runs/11805232960/job/32887228609#step:6:157

The rate limiting is for the downloads from the GitHub container registry. As a solution, this PR adds the public ECR registry as a fallback option when the rate limit hits with the GitHub container registry.

Workflow run with this fix: https://github.com/ballerina-platform/module-ballerina-time/actions/runs/11810431587/job/32902393393#step:6:170

Reference: https://github.com/aquasecurity/trivy-action/issues/389