### PR TITLE
Update set up ballerina version to nightly

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
-          version: latest
+          version: nightly
 
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1


### PR DESCRIPTION
## Purpose

For testing Java 21 migration with connectors

This should be reverted after the update 11 release
Related issue: https://github.com/ballerina-platform/ballerina-library/issues/7515