### PR TITLE
Fix Codecov Slug Path

### DIFF
--- a/.github/workflows/build-connector-template.yml
+++ b/.github/workflows/build-connector-template.yml
@@ -77,7 +77,7 @@ jobs:
               uses: codecov/codecov-action@v5
               with:
                 token: ${{ secrets.CODECOV_TOKEN }}
-                slug: ballerina-platform/${{ github.event.inputs.repo }}
+                slug: ballerina-platform/${{ github.event.repository.name }}
 
             -   name: Publish Connector
                 if: ${{ inputs.publish-required == true }}

--- a/.github/workflows/build-timestamp-master-template.yml
+++ b/.github/workflows/build-timestamp-master-template.yml
@@ -50,7 +50,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: ballerina-platform/${{ github.event.inputs.repo }}
+          slug: ballerina-platform/${{ github.event.repository.name }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr-build-connector-template.yml
+++ b/.github/workflows/pr-build-connector-template.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
         default: ""
-        
+
 jobs:
     ubuntu-build:
         name: Build
@@ -59,4 +59,4 @@ jobs:
               uses: codecov/codecov-action@v5
               with:
                 token: ${{ secrets.CODECOV_TOKEN }}
-                slug: ballerina-platform/${{ github.event.inputs.repo }}
+                slug: ballerina-platform/${{ github.event.repository.name }}

--- a/.github/workflows/pull-request-build-template.yml
+++ b/.github/workflows/pull-request-build-template.yml
@@ -56,7 +56,7 @@ jobs:
               uses: codecov/codecov-action@v5
               with:
                 token: ${{ secrets.CODECOV_TOKEN }}
-                slug: ballerina-platform/${{ github.event.inputs.repo }}
+                slug: ballerina-platform/${{ github.event.repository.name }}
 
     windows-build:
         name: Build on Windows

--- a/.github/workflows/s4hana-build-connector-template.yml
+++ b/.github/workflows/s4hana-build-connector-template.yml
@@ -106,4 +106,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: ballerina-platform/${{ github.event.inputs.repo }}
+          slug: ballerina-platform/${{ github.event.repository.name }}

--- a/.github/workflows/s4hana-pr-template.yml
+++ b/.github/workflows/s4hana-pr-template.yml
@@ -72,7 +72,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: ballerina-platform/${{ github.event.inputs.repo }}
+          slug: ballerina-platform/${{ github.event.repository.name }}
 
   build-examples:
     name: Build Examples


### PR DESCRIPTION
## Purpose

The current CodeCov slug path is invalid, leading to not publishing the codecov report. This will fix it.