### PR TITLE
Update auto PR merge step to only check for PR Build Status in Regenerate OpenAPI Connectors Workflow

### DIFF
--- a/.github/workflows/regenerate-connector-template.yml
+++ b/.github/workflows/regenerate-connector-template.yml
@@ -236,7 +236,6 @@ jobs:
 
           while [[ $retry_count -lt $max_retries ]]
           do
-            sleep 20
             retry_count=$((retry_count + 1))
             
             echo "[$retry_count/$max_retries] Checking PR Build Workflow status..."
@@ -246,6 +245,7 @@ jobs:
               --json statusCheckRollup)
 
             if [[ -z "$result" ]]; then
+              sleep 20
               continue
             fi
 

--- a/.github/workflows/regenerate-connector-template.yml
+++ b/.github/workflows/regenerate-connector-template.yml
@@ -231,15 +231,24 @@ jobs:
       - name: Merge PR
         if: ${{ steps.commitFiles.outputs.hasChanged == 'true' && inputs.auto-merge == true }}
         run: |
-          checkCount="0"
-          while [ "$checkCount" != "1" ]
+          while true
           do
             sleep 20
-            checkCount=$(gh pr view ${{ steps.createPR.outputs.prUrl }} --jq '[.statusCheckRollup[] | select((.conclusion=="SUCCESS") and ((.name=="Run PR Build Workflow / Build")))] | length' --json statusCheckRollup)
-            failedCount=$(gh pr view ${{ steps.createPR.outputs.prUrl }} --jq '[.statusCheckRollup[] | select((.conclusion=="FAILURE") and ((.name=="Run PR Build Workflow / Build")))] | length' --json statusCheckRollup)
-            if [[ "$failedCount" != "0" ]]
-            then
-              echo "PR Build has Failed"
+            result=$(gh pr view ${{ steps.createPR.outputs.prUrl }} \
+              --jq '[.statusCheckRollup[] | select((.name == "Run PR Build Workflow / Build") and (.status == "COMPLETED"))][0]' \
+              --json statusCheckRollup)
+
+            if [[ -z "$result" ]]; then
+              echo "Waiting for PR Build Workflow to complete..."
+              continue
+            fi
+
+            conclusion=$(echo "$result" | jq -r '.conclusion')
+            if [[ "$conclusion" == "SUCCESS" ]]; then
+              echo "PR Build Workflow succeeded."
+              break
+            else
+              echo "PR Build Workflow failed with conclusion: $conclusion"
               exit 1
             fi
           done

--- a/.github/workflows/regenerate-connector-template.yml
+++ b/.github/workflows/regenerate-connector-template.yml
@@ -231,24 +231,16 @@ jobs:
       - name: Merge PR
         if: ${{ steps.commitFiles.outputs.hasChanged == 'true' && inputs.auto-merge == true }}
         run: |
-          checkComplete="0"
-          while [ "$checkComplete" != "1" ]; do
+          checkCount="0"
+          while [ "$checkCount" != "1" ]
+          do
             sleep 20
-
-            allChecks=$(gh pr status --json statusCheckRollup --jq '.currentBranch.statusCheckRollup')
-            failedCount=$(echo "$allChecks" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED")] | length')
-            incompleteCount=$(echo "$allChecks" | jq '[.[] | select(.conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "FAILURE" and .conclusion != "CANCELLED")] | length')
-
-            if [[ "$failedCount" -gt 0 ]]; then
-              echo "Some status checks failed or were cancelled."
+            checkCount=$(gh pr view ${{ steps.createPR.outputs.prUrl }} --jq '[.statusCheckRollup[] | select((.conclusion=="SUCCESS") and ((.name=="Run PR Build Workflow / Build")))] | length' --json statusCheckRollup)
+            failedCount=$(gh pr view ${{ steps.createPR.outputs.prUrl }} --jq '[.statusCheckRollup[] | select((.conclusion=="FAILURE") and ((.name=="Run PR Build Workflow / Build")))] | length' --json statusCheckRollup)
+            if [[ "$failedCount" != "0" ]]
+            then
+              echo "PR Build has Failed"
               exit 1
-            fi
-
-            if [[ "$incompleteCount" -eq 0 ]]; then
-              checkComplete="1"
-              echo "All required checks have passed."
-            else
-              echo "Waiting for checks to complete... ($incompleteCount remaining)"
             fi
           done
           sleep 20

--- a/.github/workflows/regenerate-connector-template.yml
+++ b/.github/workflows/regenerate-connector-template.yml
@@ -265,7 +265,7 @@ jobs:
             exit 1
           fi
 
-          sleep 20
+          sleep 5
           gh pr merge --merge --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/.github/workflows/regenerate-connector-template.yml
+++ b/.github/workflows/regenerate-connector-template.yml
@@ -231,19 +231,26 @@ jobs:
       - name: Merge PR
         if: ${{ steps.commitFiles.outputs.hasChanged == 'true' && inputs.auto-merge == true }}
         run: |
-          while true
+          max_retries=100
+          retry_count=0
+
+          while [[ $retry_count -lt $max_retries ]]
           do
             sleep 20
+            retry_count=$((retry_count + 1))
+            
+            echo "[$retry_count/$max_retries] Checking PR Build Workflow status..."
+
             result=$(gh pr view ${{ steps.createPR.outputs.prUrl }} \
               --jq '[.statusCheckRollup[] | select((.name == "Run PR Build Workflow / Build") and (.status == "COMPLETED"))][0]' \
               --json statusCheckRollup)
 
             if [[ -z "$result" ]]; then
-              echo "Waiting for PR Build Workflow to complete..."
               continue
             fi
 
             conclusion=$(echo "$result" | jq -r '.conclusion')
+
             if [[ "$conclusion" == "SUCCESS" ]]; then
               echo "PR Build Workflow succeeded."
               break
@@ -252,6 +259,12 @@ jobs:
               exit 1
             fi
           done
+
+          if [[ $retry_count -ge $max_retries ]]; then
+            echo "Reached max retry limit ($max_retries). Workflow did not complete in time."
+            exit 1
+          fi
+
           sleep 20
           gh pr merge --merge --delete-branch
         env:


### PR DESCRIPTION
## Purpose
> $subject

Resolves [Connector Regeneration Workflow Should Only Check the PR Build Status ](https://github.com/ballerina-platform/ballerina-library/issues/7803)
