### PR TITLE
Sent connector regeneration PR only when there is a change in regeneration

### DIFF
--- a/.github/workflows/regenerate-connector-template.yml
+++ b/.github/workflows/regenerate-connector-template.yml
@@ -182,7 +182,6 @@ jobs:
           git add docs/spec/
           if ! git diff --cached --quiet; then
             git commit -m "[AUTOMATED] Update OpenAPI spec"
-            changed=true
           fi
 
           # Second commit: all other changes
@@ -198,7 +197,7 @@ jobs:
             echo "hasChanged=true" >> $GITHUB_OUTPUT
           else
             echo "hasChanged=false" >> $GITHUB_OUTPUT
-            echo "No changes to commit."
+            echo "No changes in the client generation to commit."
           fi
 
       - name: Push Results


### PR DESCRIPTION
## Purpose

There can be instances where the specification get changed(order of the schema fields) after flattening or aligning but there is no change in the generated code. We need to skip sending PR in such scenarios