### PR TITLE
Fix dashboard update failure due to repo name change

### DIFF
--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -82,7 +82,7 @@
             "name": "module-ballerina-mqtt"
         },
         {
-            "name": "module-ballerina-np"
+            "name": "module-ballerina-ai.np"
         },
         {
             "name": "module-ballerina-oauth2",


### PR DESCRIPTION
## Purpose

> $Subject

Failure: https://github.com/ballerina-platform/ballerina-library/actions/runs/17602040361/job/50005849135#step:5:34

Due to the name change we are getting a redirect response. Since the Github client is not configured to follow redirects, currently it is failing with data-binding error.