### PR TITLE
Migrate to Java 25 and Gradle 9.5.1 (without Java source changes)

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -38,11 +38,18 @@ jobs:
         if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Skip GraalVM Check')
 
         steps:
-            - name: Set up GraalVM for JDK 25
+            - name: Set up JDK 25
               uses: actions/setup-java@v4
               with:
-                  distribution: 'graalvm-community'
+                  distribution: 'temurin'
                   java-version: '25'
+
+            - name: Set up GraalVM
+              uses: graalvm/setup-graalvm@v1
+              with:
+                  java-version: '25'
+                  distribution: 'graalvm-community'
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Checkout Ballerina Lang Repository
               if: ${{ inputs.lang_version == '' && github.event_name != 'pull_request' }}
@@ -99,11 +106,18 @@ jobs:
         if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Skip GraalVM Check')
 
         steps:
-            - name: Set up GraalVM for JDK 25
+            - name: Set up JDK 25
               uses: actions/setup-java@v4
               with:
-                  distribution: 'graalvm-community'
+                  distribution: 'temurin'
                   java-version: '25'
+
+            - name: Set up GraalVM
+              uses: graalvm/setup-graalvm@v1
+              with:
+                  java-version: '25'
+                  distribution: 'graalvm-community'
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Git configure long path
               run: |

--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -38,10 +38,10 @@ jobs:
         if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Skip GraalVM Check')
 
         steps:
-            - name: Set up JDK 25
+            - name: Set up GraalVM for JDK 25
               uses: actions/setup-java@v4
               with:
-                  distribution: 'temurin'
+                  distribution: 'graalvm-community'
                   java-version: '25'
 
             - name: Checkout Ballerina Lang Repository
@@ -68,20 +68,6 @@ jobs:
               run: |
                   perl -pi -e "s/^\s*version=.*/version=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew build -x test publishToMavenLocal --scan --no-daemon
-
-            - name: Set up GraalVM
-              uses: graalvm/setup-graalvm@v1
-              with:
-                  java-version: '25'
-                  distribution: 'graalvm-community'
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  set-java-home: 'false'
-
-            - name: Check GraalVM installation
-              run: |
-                  echo "GRAALVM_HOME: ${{ env.GRAALVM_HOME }}"
-                  echo "JAVA_HOME: ${{ env.JAVA_HOME }}"
-                  native-image --version
 
             - name: Checkout Module Repository
               uses: actions/checkout@v3
@@ -113,10 +99,10 @@ jobs:
         if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Skip GraalVM Check')
 
         steps:
-            - name: Set up JDK 25
+            - name: Set up GraalVM for JDK 25
               uses: actions/setup-java@v4
               with:
-                  distribution: 'temurin'
+                  distribution: 'graalvm-community'
                   java-version: '25'
 
             - name: Git configure long path
@@ -158,21 +144,6 @@ jobs:
               run: |
                   perl -pi -e "s/^\s*version=.*/version=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew.bat build -x test publishToMavenLocal --continue -x javadoc --stacktrace -scan --console=plain --no-daemon --no-parallel
-
-            - name: Set up GraalVM
-              uses: graalvm/setup-graalvm@v1
-              with:
-                  java-version: '25'
-                  distribution: 'graalvm-community'
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  set-java-home: 'false'
-
-            - name: Check GraalVM installation
-              run: |
-                  Write-Output GRAALVM_HOME: "${{ env.GRAALVM_HOME }}"
-                  Write-Output JAVA_HOME: "${{ env.JAVA_HOME }}"
-                  native-image --version
-                  git config --system core.longpaths true
 
             - name: Checkout Module Repository
               uses: actions/checkout@v3

--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -38,11 +38,11 @@ jobs:
         if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Skip GraalVM Check')
 
         steps:
-            - name: Set up JDK 21
-              uses: actions/setup-java@v3
+            - name: Set up JDK 25
+              uses: actions/setup-java@v4
               with:
                   distribution: 'temurin'
-                  java-version: '21'
+                  java-version: '25'
 
             - name: Checkout Ballerina Lang Repository
               if: ${{ inputs.lang_version == '' && github.event_name != 'pull_request' }}
@@ -72,7 +72,7 @@ jobs:
             - name: Set up GraalVM
               uses: graalvm/setup-graalvm@v1
               with:
-                  java-version: '21'
+                  java-version: '25'
                   distribution: 'graalvm-community'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   set-java-home: 'false'
@@ -113,11 +113,11 @@ jobs:
         if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Skip GraalVM Check')
 
         steps:
-            - name: Set up JDK 21
-              uses: actions/setup-java@v3
+            - name: Set up JDK 25
+              uses: actions/setup-java@v4
               with:
                   distribution: 'temurin'
-                  java-version: '21'
+                  java-version: '25'
 
             - name: Git configure long path
               run: |
@@ -162,7 +162,7 @@ jobs:
             - name: Set up GraalVM
               uses: graalvm/setup-graalvm@v1
               with:
-                  java-version: '21'
+                  java-version: '25'
                   distribution: 'graalvm-community'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   set-java-home: 'false'

--- a/.github/workflows/pull-request-build-template.yml
+++ b/.github/workflows/pull-request-build-template.yml
@@ -32,13 +32,13 @@ jobs:
           cancel-in-progress: true
         steps:
             -   name: Checkout Repository
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
 
-            -   name: Set up JDK 21
-                uses: actions/setup-java@v3
+            -   name: Set up JDK 25
+                uses: actions/setup-java@v4
                 with:
                     distribution: 'temurin'
-                    java-version: 21.0.3
+                    java-version: 25
 
             - name: Set ENV Variables
               run: |
@@ -66,13 +66,13 @@ jobs:
           cancel-in-progress: true
         steps:
             -   name: Checkout Repository
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
 
-            -   name: Set up JDK 21
-                uses: actions/setup-java@v3
+            -   name: Set up JDK 25
+                uses: actions/setup-java@v4
                 with:
                     distribution: 'temurin'
-                    java-version: 21.0.3
+                    java-version: 25
 
             - name: Set ENV Variables
               run: |

--- a/.github/workflows/pull-request-build-template.yml
+++ b/.github/workflows/pull-request-build-template.yml
@@ -44,6 +44,11 @@ jobs:
               run: |
                 echo -e '${{ toJson(secrets) }}' | jq -r 'to_entries[] | .key + "=" + .value' >> $GITHUB_ENV
 
+            -   name: Set git user identity
+                run: |
+                  git config --global user.name "ballerina-bot"
+                  git config --global user.email "ballerina-bot@ballerina.org"
+
             -   name: Build the Package
                 env:
                     packageUser: ${{ github.actor }}
@@ -77,6 +82,11 @@ jobs:
             - name: Set ENV Variables
               run: |
                 echo '${{ toJson(secrets) }}' | jq -r 'to_entries[] | .key + "=" + .value' | Out-File -FilePath $env:GITHUB_ENV -Append
+
+            -   name: Set git user identity
+                run: |
+                  git config --global user.name "ballerina-bot"
+                  git config --global user.email "ballerina-bot@ballerina.org"
 
             -   name: Build the Project
                 env:


### PR DESCRIPTION
## Purpose

Migrates the CI workflows to Java 25 and GraalVM for Java 25, excluding any Java source (`*.java`) changes. This branch contains only build/workflow updates carried over from `java-25-migration`:

- `.github/workflows/build-with-bal-test-graalvm-template.yml`: JDK upgraded from 21 to 25 (`actions/setup-java@v4`), GraalVM setup moved earlier in the job and updated to Java 25, removed the now-redundant separate GraalVM installation check step.
- `.github/workflows/pull-request-build-template.yml`: `actions/checkout` upgraded to v4, JDK upgraded from 21 to 25, added a git identity setup step for `commitTomlFiles` compatibility.

Verified that the diff against `main` (three-dot, matching what this PR will show) contains no `*.java` files — the `java-25-migration` branch itself made zero net Java source changes; the migration was CI/workflow-only.