### PR TITLE
Add zip to the library module list

### DIFF
--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -159,6 +159,9 @@
         },
         {
             "name": "module-ballerina-yaml"
+        },
+        {
+            "name": "module-ballerina-zip"
         }
     ],
     "extended_modules": [


### PR DESCRIPTION
## Purpose

Register [`module-ballerina-zip`](https://github.com/ballerina-platform/module-ballerina-zip) under `library_modules` in `release/resources/module_list.json`, so the module appears on the Standard Library Status Dashboard and is picked up by the library release pipeline.

## Changes

- Added `module-ballerina-zip` to `library_modules` (alphabetical position, after `module-ballerina-yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds `module-ballerina-zip` to `library_modules` in `release/resources/module_list.json`. This enables the module to appear on the Standard Library Status Dashboard and enter the library release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->