### PR TITLE
Fall back to connector-style workflow names in the dashboard

### DIFF
--- a/dashboard/constants.bal
+++ b/dashboard/constants.bal
@@ -81,3 +81,7 @@ const WORKFLOW_TRIVY = "trivy-scan.yml";
 const WORKFLOW_MASTER_CI_BUILD = "daily-build.yml";
 const WORKFLOW_PROCESS_LOAD_TESTS = "process-load-test-result.yml";
 const WORKFLOW_BAL_TEST_GRAALVM = "build-with-bal-test-graalvm.yml";
+
+// Fallback workflow files, used by the repositories created off the connector templates
+const WORKFLOW_CONNECTOR_BUILD = "ci.yml";
+const WORKFLOW_BAL_TEST_NATIVE = "build-with-bal-test-native.yml";

--- a/dashboard/github.bal
+++ b/dashboard/github.bal
@@ -52,14 +52,15 @@ isolated function getRepoBadges(Module module) returns RepoBadges|error {
         bugs: check getBugsBadge(moduleName)
     };
 
+    string[] workflowFileNames = [];
+    string? buildWorkflow = ();
+    string? graalvmCheckWorkflow = ();
+
     foreach github:Workflow workflow in workflowResponse.workflows {
         string workflowFileName = getWorkflowFileName(workflow.path);
+        workflowFileNames.push(workflowFileName);
         if workflowFileName == WORKFLOW_MASTER_BUILD || workflowFileName == WORKFLOW_MASTER_CI_BUILD {
-            repoBadges.buildStatus = {
-                name: "Build",
-                badgeUrl: getBadgeUrl(moduleName, workflowFileName, defaultBranch),
-                htmlUrl: getWorkflowUrl(moduleName, workflowFileName)
-            };
+            buildWorkflow = workflowFileName;
         }
         if workflowFileName == WORKFLOW_TRIVY {
             string workflowUrl = getWorkflowUrl(moduleName, workflowFileName);
@@ -85,12 +86,31 @@ isolated function getRepoBadges(Module module) returns RepoBadges|error {
             };
         }
         if workflowFileName == WORKFLOW_BAL_TEST_GRAALVM {
-            repoBadges.graalvmCheck = {
-                name: "GraalVM Check",
-                badgeUrl: getBadgeUrl(moduleName, workflowFileName, defaultBranch),
-                htmlUrl: getWorkflowUrl(moduleName, workflowFileName)
-            };
+            graalvmCheckWorkflow = workflowFileName;
         }
+    }
+
+    // The standard names are always preferred; the connector-style names are picked only when those are absent
+    if buildWorkflow is () && workflowFileNames.indexOf(WORKFLOW_CONNECTOR_BUILD) is int {
+        buildWorkflow = WORKFLOW_CONNECTOR_BUILD;
+    }
+    if graalvmCheckWorkflow is () && workflowFileNames.indexOf(WORKFLOW_BAL_TEST_NATIVE) is int {
+        graalvmCheckWorkflow = WORKFLOW_BAL_TEST_NATIVE;
+    }
+
+    if buildWorkflow is string {
+        repoBadges.buildStatus = {
+            name: "Build",
+            badgeUrl: getBadgeUrl(moduleName, buildWorkflow, defaultBranch),
+            htmlUrl: getWorkflowUrl(moduleName, buildWorkflow)
+        };
+    }
+    if graalvmCheckWorkflow is string {
+        repoBadges.graalvmCheck = {
+            name: "GraalVM Check",
+            badgeUrl: getBadgeUrl(moduleName, graalvmCheckWorkflow, defaultBranch),
+            htmlUrl: getWorkflowUrl(moduleName, graalvmCheckWorkflow)
+        };
     }
     return repoBadges;
 }


### PR DESCRIPTION
## Purpose

The Status Dashboard resolves the **Build** and **GraalVM Check** badges by matching workflow *file names* against a fixed set of standard library names:

- Build → `build-timestamped-master.yml` or `daily-build.yml`
- GraalVM Check → `build-with-bal-test-graalvm.yml`

Repositories created off the connector templates (`library-templates/generated-connector-template`) name the same workflows differently — `ci.yml` and `build-with-bal-test-native.yml` — so the dashboard finds nothing and renders N/A even though the workflows exist and run.

Affected repos include `module-ballerina-zip` (both columns), `ballerinax/openai` and `ballerinax/paypal.orders` (Build), and `ballerinax/snowflake` (GraalVM Check).

## Changes

- Added `WORKFLOW_CONNECTOR_BUILD` (`ci.yml`) and `WORKFLOW_BAL_TEST_NATIVE` (`build-with-bal-test-native.yml`) as fallbacks.
- `getRepoBadges` now collects the workflow file names first and resolves the two badges after the loop. The standard names keep precedence — a fallback is used only when no standard name is present — so rows for repos carrying both names (e.g. `ballerinax/mongodb`, `ballerinax/kafka`) are unchanged.

## Checks

- `bal build` passes.
- `bal test`: the 2 failures (`getCodecovBadgeTest`, `getPullRequestsBadgeTest`) are pre-existing on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added fallback support for connector-style workflow filenames in Build and GraalVM Check badge resolution.
- Preserved standard workflow precedence when both workflow types exist.
- Improved badge resolution by collecting workflow filenames before selecting badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->