### PR TITLE
Add otel to the library module list

### DIFF
--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -162,6 +162,9 @@
         },
         {
             "name": "module-ballerina-zip"
+        },
+        {
+            "name": "module-ballerina-otel"
         }
     ],
     "extended_modules": [


### PR DESCRIPTION
## Purpose

Register [`module-ballerina-otel`](https://github.com/ballerina-platform/module-ballerina-otel) under `library_modules` in `release/resources/module_list.json`, so the module appears on the Standard Library Status Dashboard and is picked up by the library release pipeline.

## Changes

- Added `module-ballerina-otel` to `library_modules` (after `module-ballerina-zip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds `module-ballerina-otel` to the Ballerina standard library module registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->