### PR TITLE
Add bal scan job to the security scan workflow

### DIFF
--- a/.github/workflows/security-scan-template.yml
+++ b/.github/workflows/security-scan-template.yml
@@ -14,43 +14,8 @@ on:
         default: "ballerina"
 
 jobs:
-  trivy-scan:
-    name: Trivy Vulnerability Scan
-    runs-on: ubuntu-22.04
-    if: github.repository_owner == 'ballerina-platform'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: 21.0.3
-
-      - name: Build with Gradle
-        env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
-
-      - name: Create lib directory if not exists
-        run: mkdir -p ballerina/lib
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
-        with:
-          scan-type: "rootfs"
-          scan-ref: "${{ github.workspace }}/ballerina/lib"
-          format: "table"
-          timeout: "10m0s"
-          exit-code: "1"
-          scanners: "vuln"
-          cache-dir: "/tmp/trivy-cache"
-
-  bal-scan:
-    name: Ballerina Static Code Analysis
+  security-scan:
+    name: Security Scan
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'ballerina-platform'
     steps:
@@ -75,14 +40,36 @@ jobs:
           distribution: "temurin"
           java-version: 21.0.3
 
-      # bal scan needs the package to compile, which for Java-interop modules means the
-      # native jar(s) referenced under [[platform.javaXX.dependency]] in Ballerina.toml
-      # must already be built.
+      # Built once and shared by both scans below: Trivy scans the built jars under
+      # ballerina/lib, and bal scan needs the native jar(s) referenced under
+      # [[platform.javaXX.dependency]] in Ballerina.toml to already be built in order
+      # to compile the package.
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
+
+      - name: Create lib directory if not exists
+        run: mkdir -p ballerina/lib
+
+      # continue-on-error so a Trivy finding doesn't skip the bal scan steps below;
+      # its outcome is checked explicitly in the final step instead.
+      - name: Run Trivy vulnerability scanner
+        id: trivy
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        with:
+          scan-type: "rootfs"
+          scan-ref: "${{ github.workspace }}/ballerina/lib"
+          format: "table"
+          timeout: "10m0s"
+          exit-code: "1"
+          scanners: "vuln"
+          cache-dir: "/tmp/trivy-cache"
 
       - name: Pull the bal scan tool
         run: bal tool pull scan
@@ -102,15 +89,26 @@ jobs:
 
       # bal scan always exits 0, so pass/fail is derived from the report: real
       # VULNERABILITY findings fail the job, CODE_SMELL findings are reported only
-      # (via the uploaded artifact) since existing style debt shouldn't break nightly runs.
+      # (via the uploaded artifact) since existing style debt shouldn't break nightly
+      # runs. Combined here with the Trivy outcome so the job fails if either scanner
+      # found something, regardless of order.
       - name: Fail the job if vulnerabilities are found
         working-directory: ${{ inputs.scan-path }}
         run: |
           VULN_COUNT=$(jq '[.[] | select(.rule.ruleKind == "VULNERABILITY")] | length' target/report/scan_results.json)
           SMELL_COUNT=$(jq '[.[] | select(.rule.ruleKind == "CODE_SMELL")] | length' target/report/scan_results.json)
           echo "bal scan found $VULN_COUNT vulnerability finding(s) and $SMELL_COUNT code smell finding(s). See the bal-scan-report artifact for details."
+
+          FAIL=0
           if [ "$VULN_COUNT" -gt 0 ]; then
             jq '[.[] | select(.rule.ruleKind == "VULNERABILITY")]' target/report/scan_results.json
-            echo "::error::bal scan found $VULN_COUNT vulnerability finding(s). Failing the job."
+            echo "::error::bal scan found $VULN_COUNT vulnerability finding(s)."
+            FAIL=1
+          fi
+          if [ "${{ steps.trivy.outcome }}" == "failure" ]; then
+            echo "::error::Trivy vulnerability scanner found issue(s). See the 'Run Trivy vulnerability scanner' step above."
+            FAIL=1
+          fi
+          if [ "$FAIL" -eq 1 ]; then
             exit 1
           fi

--- a/.github/workflows/security-scan-template.yml
+++ b/.github/workflows/security-scan-template.yml
@@ -1,0 +1,116 @@
+name: Security Scan
+
+on:
+  workflow_call:
+    inputs:
+      additional-build-flags:
+        required: false
+        type: string
+        default: ""
+      scan-path:
+        description: "Path to the Ballerina package to run 'bal scan' against"
+        required: false
+        type: string
+        default: "ballerina"
+
+jobs:
+  trivy-scan:
+    name: Trivy Vulnerability Scan
+    runs-on: ubuntu-22.04
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 21.0.3
+
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
+
+      - name: Create lib directory if not exists
+        run: mkdir -p ballerina/lib
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        with:
+          scan-type: "rootfs"
+          scan-ref: "${{ github.workspace }}/ballerina/lib"
+          format: "table"
+          timeout: "10m0s"
+          exit-code: "1"
+          scanners: "vuln"
+          cache-dir: "/tmp/trivy-cache"
+
+  bal-scan:
+    name: Ballerina Static Code Analysis
+    runs-on: ubuntu-22.04
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get Ballerina Version
+        run: |
+          BAL_VERSION=$(grep -w 'ballerinaLangVersion' gradle.properties | cut -d= -f2 | rev | cut --complement -d- -f1 | rev)
+          if [ -z "$BAL_VERSION" ]; then
+            BAL_VERSION="latest"
+          fi
+          echo "BAL_VERSION=$BAL_VERSION" >> $GITHUB_ENV
+
+      - name: Set up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.3
+        with:
+          version: ${{ env.BAL_VERSION }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 21.0.3
+
+      # bal scan needs the package to compile, which for Java-interop modules means the
+      # native jar(s) referenced under [[platform.javaXX.dependency]] in Ballerina.toml
+      # must already be built.
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
+
+      - name: Pull the bal scan tool
+        run: bal tool pull scan
+
+      - name: Run bal scan
+        working-directory: ${{ inputs.scan-path }}
+        run: bal scan --scan-report
+
+      - name: Upload bal scan report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bal-scan-report
+          path: ${{ inputs.scan-path }}/target/report
+          retention-days: 30
+          if-no-files-found: ignore
+
+      # bal scan always exits 0, so pass/fail is derived from the report: real
+      # VULNERABILITY findings fail the job, CODE_SMELL findings are reported only
+      # (via the uploaded artifact) since existing style debt shouldn't break nightly runs.
+      - name: Fail the job if vulnerabilities are found
+        working-directory: ${{ inputs.scan-path }}
+        run: |
+          VULN_COUNT=$(jq '[.[] | select(.rule.ruleKind == "VULNERABILITY")] | length' target/report/scan_results.json)
+          SMELL_COUNT=$(jq '[.[] | select(.rule.ruleKind == "CODE_SMELL")] | length' target/report/scan_results.json)
+          echo "bal scan found $VULN_COUNT vulnerability finding(s) and $SMELL_COUNT code smell finding(s). See the bal-scan-report artifact for details."
+          if [ "$VULN_COUNT" -gt 0 ]; then
+            jq '[.[] | select(.rule.ruleKind == "VULNERABILITY")]' target/report/scan_results.json
+            echo "::error::bal scan found $VULN_COUNT vulnerability finding(s). Failing the job."
+            exit 1
+          fi

--- a/.github/workflows/security-scan-template.yml
+++ b/.github/workflows/security-scan-template.yml
@@ -14,12 +14,82 @@ on:
         default: "ballerina"
 
 jobs:
-  security-scan:
-    name: Security Scan
+  build:
+    name: Build
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'ballerina-platform'
     steps:
       - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 21.0.3
+
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
+
+      - name: Create lib directory if not exists
+        run: mkdir -p ballerina/lib
+
+      # Shared with the trivy-scan and bal-scan jobs below so the package is only built
+      # once: ballerina/lib is what Trivy scans, and **/build/libs/*.jar covers every
+      # subproject's packaged jar (e.g. a module's own native implementation jar), which
+      # bal scan needs to resolve the platform dependencies declared in Ballerina.toml
+      # in order to compile the package.
+      - name: Upload build output
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            ballerina/lib/**
+            **/build/libs/*.jar
+          if-no-files-found: warn
+          retention-days: 1
+
+  trivy-scan:
+    name: Trivy Vulnerability Scan
+    needs: build
+    runs-on: ubuntu-22.04
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - name: Download build output
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        with:
+          scan-type: "rootfs"
+          scan-ref: "${{ github.workspace }}/ballerina/lib"
+          format: "table"
+          timeout: "10m0s"
+          exit-code: "1"
+          scanners: "vuln"
+          cache-dir: "/tmp/trivy-cache"
+
+  bal-scan:
+    name: Ballerina Static Code Analysis
+    needs: build
+    runs-on: ubuntu-22.04
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - uses: actions/checkout@v3
+
+      # Overlays the jars built once by the build job onto this fresh checkout, at the
+      # same relative paths Ballerina.toml expects (e.g. ballerina/lib/*.jar,
+      # native/build/libs/*.jar), so bal scan can compile without rebuilding.
+      - name: Download build output
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
 
       - name: Get Ballerina Version
         run: |
@@ -33,43 +103,6 @@ jobs:
         uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: ${{ env.BAL_VERSION }}
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: 21.0.3
-
-      # Built once and shared by both scans below: Trivy scans the built jars under
-      # ballerina/lib, and bal scan needs the native jar(s) referenced under
-      # [[platform.javaXX.dependency]] in Ballerina.toml to already be built in order
-      # to compile the package.
-      - name: Build with Gradle
-        env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
-
-      - name: Create lib directory if not exists
-        run: mkdir -p ballerina/lib
-
-      # continue-on-error so a Trivy finding doesn't skip the bal scan steps below;
-      # its outcome is checked explicitly in the final step instead.
-      - name: Run Trivy vulnerability scanner
-        id: trivy
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
-        with:
-          scan-type: "rootfs"
-          scan-ref: "${{ github.workspace }}/ballerina/lib"
-          format: "table"
-          timeout: "10m0s"
-          exit-code: "1"
-          scanners: "vuln"
-          cache-dir: "/tmp/trivy-cache"
 
       - name: Pull the bal scan tool
         run: bal tool pull scan
@@ -89,26 +122,15 @@ jobs:
 
       # bal scan always exits 0, so pass/fail is derived from the report: real
       # VULNERABILITY findings fail the job, CODE_SMELL findings are reported only
-      # (via the uploaded artifact) since existing style debt shouldn't break nightly
-      # runs. Combined here with the Trivy outcome so the job fails if either scanner
-      # found something, regardless of order.
+      # (via the uploaded artifact) since existing style debt shouldn't break nightly runs.
       - name: Fail the job if vulnerabilities are found
         working-directory: ${{ inputs.scan-path }}
         run: |
           VULN_COUNT=$(jq '[.[] | select(.rule.ruleKind == "VULNERABILITY")] | length' target/report/scan_results.json)
           SMELL_COUNT=$(jq '[.[] | select(.rule.ruleKind == "CODE_SMELL")] | length' target/report/scan_results.json)
           echo "bal scan found $VULN_COUNT vulnerability finding(s) and $SMELL_COUNT code smell finding(s). See the bal-scan-report artifact for details."
-
-          FAIL=0
           if [ "$VULN_COUNT" -gt 0 ]; then
             jq '[.[] | select(.rule.ruleKind == "VULNERABILITY")]' target/report/scan_results.json
-            echo "::error::bal scan found $VULN_COUNT vulnerability finding(s)."
-            FAIL=1
-          fi
-          if [ "${{ steps.trivy.outcome }}" == "failure" ]; then
-            echo "::error::Trivy vulnerability scanner found issue(s). See the 'Run Trivy vulnerability scanner' step above."
-            FAIL=1
-          fi
-          if [ "$FAIL" -eq 1 ]; then
+            echo "::error::bal scan found $VULN_COUNT vulnerability finding(s). Failing the job."
             exit 1
           fi

--- a/.github/workflows/trivy-scan-template.yml
+++ b/.github/workflows/trivy-scan-template.yml
@@ -1,3 +1,7 @@
+# Deprecated: kept only so existing callers referencing trivy-scan-template.yml@main
+# keep working. This forwards to security-scan-template.yml, which is now the source
+# of truth. New callers should reference security-scan-template.yml directly instead.
+# Remove this file once every caller has migrated to security-scan-template.yml.
 name: Trivy
 
 on:
@@ -9,37 +13,8 @@ on:
         default: ""
 
 jobs:
-  ubuntu-build:
-    name: Build on Ubuntu
-    runs-on: ubuntu-22.04
-    if: github.repository_owner == 'ballerina-platform'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: 21.0.3
-
-      - name: Build with Gradle
-        env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x test ${{ inputs.additional-build-flags }}
-
-      - name: Create lib directory if not exists
-        run: mkdir -p ballerina/lib
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
-        with:
-          scan-type: "rootfs"
-          scan-ref: "${{ github.workspace }}/ballerina/lib"
-          format: "table"
-          timeout: "10m0s"
-          exit-code: "1"
-          scanners: "vuln"
-          cache-dir: "/tmp/trivy-cache"
+  forward:
+    uses: ./.github/workflows/security-scan-template.yml
+    secrets: inherit
+    with:
+      additional-build-flags: ${{ inputs.additional-build-flags }}

--- a/library-templates/generated-connector-template/files/.github/workflows/security-scan.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/security-scan.yml
@@ -1,0 +1,13 @@
+name: Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 20 * * *"
+
+jobs:
+  call_workflow:
+    name: Run Security Scan Workflow
+    if: ${{ github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/security-scan-template.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a `bal-scan` job (runs `bal tool pull scan` + `bal scan`) alongside the existing Trivy job, and renames the workflow to **Security Scan**.
- The job fails only on `VULNERABILITY` findings; `CODE_SMELL` findings are uploaded as a report artifact but don't fail the job, since existing repos carry pre-existing code smells (e.g. `module-ballerina-http` alone currently has 494) that shouldn't break nightly runs across the org.
- The active workflow logic moves to `security-scan-template.yml`. `trivy-scan-template.yml` becomes a thin forwarding stub (`uses: ./.github/workflows/security-scan-template.yml`) so the ~70 repos still referencing it by that exact path keep working unchanged. Callers can migrate to `security-scan-template.yml` directly over time; the stub can be removed once everyone has.
- Adds `security-scan.yml` to the `generated-connector-template` scaffold (under `library-templates/`) so newly generated connector repos get the security scan workflow wired up automatically, pointing directly at `security-scan-template.yml`.

## Verification
- Ran `bal scan` locally against `module-ballerina-http` and `module-ballerina-cache` to confirm: report location (`target/report/scan_results.json`), that `bal scan` always exits 0 regardless of findings (so pass/fail must be derived from the report), and the `rule.ruleKind` field (`VULNERABILITY` vs `CODE_SMELL`) used for the fail gate.
- Confirmed `bal scan` needs the package's native jar dependencies already built (per `Ballerina.toml` platform dependencies), so the job runs the same `./gradlew build -x test` step used by the Trivy job before scanning.
- Validated all three YAML files parse correctly.

## Test plan
- [ ] Merge and confirm the `Security Scan` workflow runs successfully end-to-end on `ballerina-library`'s own next scheduled trigger (via a caller repo)
- [ ] Spot-check one existing repo still calling `trivy-scan-template.yml@main` to confirm the forwarding stub runs both jobs without changes on their side
- [ ] Generate a new connector repo via `apply-library-repo-templates.yml` and confirm `security-scan.yml` is created and resolves correctly

Related: wso2-enterprise/integration-engineering#2865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a reusable **Security Scan** workflow for Ballerina packages, examples, and optional scan paths.

The workflow creates separate reports, uploads them to code scanning, and fails when findings require remediation. Code-quality findings do not fail the job.

Retains the previous Trivy workflow as a forwarding stub. Adds the workflow to the generated connector template with manual and scheduled triggers. Improves input handling, action pinning, build artifact creation, and credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->